### PR TITLE
chore: set peerDependency for @remix-run/server-runtime to ^1 || ^2

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "README.md"
   ],
   "peerDependencies": {
-    "@remix-run/server-runtime": "^1.0.0"
+    "@remix-run/server-runtime": "^1 || ^2"
   },
   "devDependencies": {
     "@babel/core": "^7.14.2",


### PR DESCRIPTION
Installing remix-auth-twilio into a new project fails due to the peerDependency of @remix-run/server-runtime being ^1.0.0.  This updates it to support version 2 as well.